### PR TITLE
conditional test - do not run on PR from fork

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,12 +26,12 @@ jobs:
           npm ci
           npm run test
       
-  # test action works running from the graph
+  # Exclude running this on external forks due to permissions issue
   test-action:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}    
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: ./
       with:
         filePath: "test"
-        


### PR DESCRIPTION
✅ working (local run) - https://github.com/advanced-security/spdx-dependency-submission-action/actions/runs/14500244712
❌  broken (PR from fork) - https://github.com/advanced-security/spdx-dependency-submission-action/actions/runs/14502909863

<details><summary>403 for request POST https://api.github.com/repos/advanced-security/spdx-dependency-submission-action/dependency-graph/snapshots</summary>
<p>


```
/home/runner/work/spdx-dependency-submission-action/spdx-dependency-submission-action/webpack:/spdx-to-dependency-graph-action/node_modules/@github/dependency-submission-toolkit/dist/index.cjs:30
${JSON.stringify(n.response.data,void 0,2)}`)),n instanceof Error&&(a__namespace.error(n.message),n.stack&&a__namespace.error(n.stack)),new Error(`Failed to submit snapshot: ${n}`)}}
^
Error: Failed to submit snapshot: HttpError: Resource not accessible by integration - https://docs.github.com/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository
    at Object.L [as submitSnapshot] (/home/runner/work/spdx-dependency-submission-action/spdx-dependency-submission-action/webpack:/spdx-to-dependency-graph-action/node_modules/@github/dependency-submission-toolkit/dist/index.cjs:30:1)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
Error: HTTP Status 403 for request POST https://api.github.com/repos/advanced-security/spdx-dependency-submission-action/dependency-graph/snapshots
Error: Response body:
{
  "message": "Resource not accessible by integration",
  "documentation_url": "https://docs.github.com/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository",
  "status": "403"
}
Error: Resource not accessible by integration - https://docs.github.com/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository
Error: HttpError: Resource not accessible by integration - https://docs.github.com/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository
    at /home/runner/work/spdx-dependency-submission-action/spdx-dependency-submission-action/webpack:/spdx-to-dependency-graph-action/node_modules/@octokit/request/dist-node/index.js:125:1
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Object.L [as submitSnapshot] (/home/runner/work/spdx-dependency-submission-action/spdx-dependency-submission-action/webpack:/spdx-to-dependency-graph-action/node_modules/@github/dependency-submission-toolkit/dist/index.cjs:29:1)
```



</p>
</details> 

Workaround (this pr):
✅ working (PR from fork) -skip task - https://github.com/advanced-security/spdx-dependency-submission-action/actions/runs/14502895412