### PR TITLE
fix: pin patch-release-me to 0.6.5 (0.6.6 image missing from ghcr.io)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,10 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Patch Release Me
-        uses: 42ByteLabs/patch-release-me@04ea0a696abfc3cfbdfadb279bd9c9dd0b1652a2 # 0.6.6
+        # Pinned to 0.6.5, not the latest 0.6.6: the 0.6.6 release never published a container
+        # image to ghcr.io (upstream bug, see https://github.com/42ByteLabs/patch-release-me/issues/159).
+        # Bump back to a 0.6.6+ SHA once that's fixed and a new image is published.
+        uses: 42ByteLabs/patch-release-me@431a82795eda94d09b3821da9391c53ab287e84d # 0.6.5
         with:
           mode: ${{ inputs.bump }}
 


### PR DESCRIPTION
## Problem

`bump-version` (and the reusable-workflows repo's own self-release) fails on the `Build 42ByteLabs/patch-release-me` step:

```
ERROR: failed to build: failed to solve: ghcr.io/42bytelabs/patch-release-me:0.6.6: failed to resolve source metadata for ghcr.io/42bytelabs/patch-release-me:0.6.6: ghcr.io/42bytelabs/patch-release-me:0.6.6: not found
```

This is an upstream bug: [42ByteLabs/patch-release-me#159](https://github.com/42ByteLabs/patch-release-me/issues/159) — the `0.6.6` release published a git tag but its container-publish CI step never pushed the matching image to `ghcr.io`. There's an open fix ([#160](https://github.com/42ByteLabs/patch-release-me/pull/160)) but it isn't merged/released yet.

## Fix

Pin `42ByteLabs/patch-release-me` back to `0.6.5` (SHA `431a82795eda94d09b3821da9391c53ab287e84d`), the last release with a working `ghcr.io` image (verified via the GHCR manifest API). Same `action.yml` interface (`mode` input), no other changes needed.

Bump forward to a `0.6.6+` SHA once upstream ships a fixed release with an actual container image.