### PR TITLE
fix: skip lifecycle scripts when syncing package-lock.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,10 @@ jobs:
 
       # package-lock.json's own "version" fields aren't patched above; npm ci fails if they
       # drift from package.json, so resync the lockfile without touching resolved dependencies.
+      # --ignore-scripts: package-lock-only doesn't install devDependencies, so the "prepare"
+      # script (ncc build) would fail with "ncc: not found" if lifecycle scripts ran here.
       - name: Sync package-lock.json
-        run: npm install --package-lock-only
+        run: npm install --package-lock-only --ignore-scripts
 
       - name: Create Release PR
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1


### PR DESCRIPTION
## Problem

With the `patch-release-me` pin fixed (#145), the `bump-version` job got one step further and failed on **Sync package-lock.json**:

```
> spdx-to-dependency-graph-action@0.2.1 prepare
> ncc build index.js -o dist --source-map --license licenses.txt

sh: 1: ncc: not found
npm error code 127
```

`npm install --package-lock-only` skips installing `devDependencies` into `node_modules`, but it still fires the root package's `prepare` lifecycle script. Since `@vercel/ncc` is a devDependency, it isn't present, so the script fails.

## Fix

Add `--ignore-scripts` to the `npm install --package-lock-only` call. This step's only job is to resync `package-lock.json`'s version fields after `patch-release-me` patches `package.json` — it was never meant to build anything.

Verified locally: `npm install --package-lock-only --ignore-scripts` exits 0 against this repo's `package.json`/`package-lock.json`, where the unmodified command fails with the same `ncc: not found` error seen in CI.