### PR TITLE
fix: invoke patch-release-me via docker run to avoid mode arg quoting bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,12 +56,28 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Patch Release Me
-        # Pinned to 0.6.5, not the latest 0.6.6: the 0.6.6 release never published a container
-        # image to ghcr.io (upstream bug, see https://github.com/42ByteLabs/patch-release-me/issues/159).
-        # Bump back to a 0.6.6+ SHA once that's fixed and a new image is published.
-        uses: 42ByteLabs/patch-release-me@431a82795eda94d09b3821da9391c53ab287e84d # 0.6.5
-        with:
-          mode: ${{ inputs.bump }}
+        # Invoke the pinned patch-release-me image directly via `docker run` instead of
+        # `uses: 42ByteLabs/patch-release-me@...`. That action's own action.yml builds its
+        # Docker CMD as a single YAML list item (`-m "${{ inputs.mode }}"`); Docker container
+        # actions don't go through a shell, so the literal quote characters end up baked into
+        # ONE argv token (`-m "minor"`). clap can't match that against "patch"/"minor"/"major"
+        # and silently falls back to its own default (Patch) - so `bump: minor`/`major` have
+        # always quietly produced a patch bump instead (see
+        # https://github.com/42ByteLabs/patch-release-me/issues/161, fixed upstream in
+        # https://github.com/42ByteLabs/patch-release-me/pull/162, not yet merged/released).
+        # Running the same pinned image ourselves via a normal shell `run:` step naturally
+        # splits `-m` and the mode value into separate argv entries, avoiding the bug entirely.
+        # Pinned by digest (not just tag) so the exact image content can't change out from
+        # under us - digest corresponds to the 0.6.5 tag, the last one with a published image
+        # (see https://github.com/42ByteLabs/patch-release-me/issues/159 for why 0.6.6 isn't used).
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -v "${{ github.workspace }}:/repo" \
+            -w /repo \
+            ghcr.io/42bytelabs/patch-release-me@sha256:d9d7abe7051855d0c395fec99d931acc002fb6b299ca16b8123e2c8ef0c7e750 \
+            --disable-banner bump -m ${{ inputs.bump }}
 
       - name: Setup Node
         uses: actions/setup-node@v7.0.0


### PR DESCRIPTION
Fixes a real, silent bug where `bump: minor`/`major` (workflow_dispatch input) has always quietly produced a **patch** bump instead - confirmed live in #147 (closed), which requested `bump: minor` and produced `0.2.0 -> 0.2.1`.

## Root cause

`42ByteLabs/patch-release-me`'s own `action.yml` builds its Docker CMD as a single YAML list item:

```yaml
args:
  - bump
  - -m "${{ inputs.mode }}"
```

Docker container actions pass `args:` directly as the container command - there's no shell in between to word-split or strip quotes. So this becomes **one** argv token: `-m "minor"` (quote characters included, literally). `clap`'s short-flag parsing then reads the mode value with the quotes attached, which doesn't match the literal strings `patch`/`minor`/`major`, so it silently falls through to its own default, `BumpMode::Patch`.

This was invisible until now because every prior run used `bump: patch`, and `Patch` is also the tool's own silent fallback - so it worked by coincidence every time.

## Fix

Stop using `uses: 42ByteLabs/patch-release-me@<sha>` for the bump step. Instead, invoke the exact same pinned image (`ghcr.io/42bytelabs/patch-release-me:0.6.5`, by digest) ourselves via a plain `run:` step. A normal shell naturally splits `-m` and the mode value into separate argv entries, sidestepping the bug entirely without needing the upstream fix to merge first.

## Related

- Upstream bug: 42ByteLabs/patch-release-me#161, fix: 42ByteLabs/patch-release-me#162 (open, unmerged, pinged maintainer with no response yet).
- Same bug independently hit and worked around the same way in GitHubSecurityLab/CodeQL-Community-Packs#171 (merged) - this PR mirrors that pattern.
- Supersedes #147, which is now closed.

## Testing

- `bump-version` job runs green end-to-end once merged (will re-dispatch `bump: minor` after this lands to confirm `0.2.0 -> 0.3.0`).
- YAML validated locally.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
