### PR TITLE
fix: rebuild dist/ during automated version bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,19 @@ jobs:
       - name: Sync package-lock.json
         run: npm install --package-lock-only --ignore-scripts
 
+      # dist/index.js is a committed, compiled bundle (see check-dist.yml) - it embeds the same
+      # VERSION const patched in index.js above, so it goes stale the moment that bump happens.
+      # This bump-version job is the only automated path that changes the version, so it's also
+      # the only place that needs to rebuild dist/ to match; mirrors check-dist.yml's own build
+      # step exactly so this PR's dist/ is byte-for-byte what check-dist expects. Needs a real
+      # `npm ci` (not --package-lock-only) to get devDependencies like @vercel/ncc installed;
+      # package-lock.json is back in sync as of the step above, so this now succeeds.
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Rebuild dist/
+        run: npm run prepare
+
       - name: Create Release PR
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
@@ -101,7 +114,8 @@ jobs:
           labels: version
           body: |
             Automated PR to bump the version tracked in `.release.yml`, and every location it
-            patches (`package.json`, `index.js`, `README.md`), plus a resynced `package-lock.json`.
+            patches (`package.json`, `index.js`, `README.md`), plus a resynced `package-lock.json`
+            and a freshly rebuilt `dist/`.
 
             Merging this to `main` automatically publishes a GitHub Release for the new version.
 


### PR DESCRIPTION
Fixes `check-dist` failing on automated bump PRs (confirmed live on #149:
https://github.com/advanced-security/spdx-dependency-submission-action/actions/runs/32536294937/job/96938390175).

## Root cause

The `bump-version` job patches `package.json`/`index.js`/`README.md` via
`patch-release-me`, but never rebuilt `dist/index.js` - the committed,
compiled bundle that `check-dist.yml` verifies on every push/PR. Since
`dist/index.js` embeds the same `VERSION` const that just got bumped in
`index.js`, it goes stale the instant the bump happens:

```
Detected uncommitted changes after build.
diff --git a/dist/index.js b/dist/index.js
Binary files a/dist/index.js and b/dist/index.js differ
```

## Fix

This `bump-version` job is the only automated path that changes the
version, so it's also the only place that needs to rebuild `dist/` to
match. Add the same `npm ci` + `npm run prepare` sequence `check-dist.yml`
itself uses, right after the `package-lock.json` resync and before opening
the PR, so `create-pull-request` picks up the rebuilt `dist/` too.

## Testing

Verified locally: bumped `package.json`/`index.js` to `0.3.0` in an
isolated copy, ran the same steps, and confirmed `dist/index.js`'s
bundled `index_VERSION` const updated to `"0.3.0"` with no `"0.2.0"`
remnants.

Will close #149 (the currently-open, dist-stale bump PR) and re-dispatch
`bump: minor` once this merges, to confirm the resulting PR passes
`check-dist` cleanly.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
