### PR TITLE
TEST: validate check-dist neutral (yellow) path - will close

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,8 @@ import { retry } from '@octokit/plugin-retry';
 import { RequestError } from '@octokit/request-error';
 import * as toolkit from '@github/dependency-submission-toolkit';
 
+// TEST: harmless comment to leave dist/ intentionally stale, validating the check-dist neutral (yellow) path. Will be reverted.
+
 /**
  * HTTP status codes that should not be retried when submitting a snapshot.
  *


### PR DESCRIPTION
Throwaway test PR to validate the check-dist neutral/yellow conclusion path live. Not for merging - will be closed after validation.