### PR TITLE
TEST: validate check-dist failure (red) path - will close

### DIFF
--- a/.release.yml
+++ b/.release.yml
@@ -1,6 +1,7 @@
 name: "spdx-dependency-submission-action"
 repository: "advanced-security/spdx-dependency-submission-action"
 version: "0.3.1"
+# TEST: harmless comment to validate check-dist failure (red) path. Will be reverted.
 
 locations:
   - name: "Node Manifest"

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,8 @@ import { retry } from '@octokit/plugin-retry';
 import { RequestError } from '@octokit/request-error';
 import * as toolkit from '@github/dependency-submission-toolkit';
 
+// TEST: harmless comment to leave dist/ intentionally stale, validating the check-dist failure (red) path. Will be reverted.
+
 /**
  * HTTP status codes that should not be retried when submitting a snapshot.
  *


### PR DESCRIPTION
Throwaway test PR to validate the check-dist failure/red conclusion path live. Not for merging - will be closed after validation.