### PR TITLE
TEST: validate check-dist neutral doesn't block required ruleset - will close

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,8 @@ import { retry } from '@octokit/plugin-retry';
 import { RequestError } from '@octokit/request-error';
 import * as toolkit from '@github/dependency-submission-toolkit';
 
+// TEST: validating that the "check-dist" required ruleset check does not block merge on a neutral conclusion. Will be reverted.
+
 /**
  * HTTP status codes that should not be retried when submitting a snapshot.
  *


### PR DESCRIPTION
Throwaway test targeting main directly to prove the check-dist required-status-check ruleset lets a neutral conclusion through without blocking. Not for merging - will be closed after validation.