### PR TITLE
TEST: validate check-dist failure blocks required ruleset (.release.yml) - will close

### DIFF
--- a/.release.yml
+++ b/.release.yml
@@ -1,6 +1,7 @@
 name: "spdx-dependency-submission-action"
 repository: "advanced-security/spdx-dependency-submission-action"
 version: "0.3.1"
+# TEST: validating check-dist failure blocks merge under required ruleset. Will be reverted.
 
 locations:
   - name: "Node Manifest"

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,8 @@ import { retry } from '@octokit/plugin-retry';
 import { RequestError } from '@octokit/request-error';
 import * as toolkit from '@github/dependency-submission-toolkit';
 
+// TEST: validating check-dist failure blocks merge under required ruleset. Will be reverted.
+
 /**
  * HTTP status codes that should not be retried when submitting a snapshot.
  *


### PR DESCRIPTION
Throwaway test targeting main directly to prove the check-dist required-status-check ruleset actually blocks merge on a failure conclusion. Touches .release.yml + leaves dist/ stale. Not for merging - will be closed after validation.