### PR TITLE
TEST: validate check-dist failure blocks required ruleset (release.yml workflow) - will close

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@
 # Delegates the tag/release mechanics to the shared reusable workflow in
 # advanced-security/reusable-workflows: https://github.com/advanced-security/reusable-workflows
 #
+# TEST: harmless comment to validate check-dist failure blocks merge under required ruleset when
+# this workflow file itself is touched. Will be reverted.
+#
 # Two ways to cut a release:
 #
 #   1. Normal flow - run this workflow (workflow_dispatch) with a "bump" type (patch/minor/major).

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,8 @@ import { retry } from '@octokit/plugin-retry';
 import { RequestError } from '@octokit/request-error';
 import * as toolkit from '@github/dependency-submission-toolkit';
 
+// TEST: validating check-dist failure blocks merge when release.yml workflow itself is touched. Will be reverted.
+
 /**
  * HTTP status codes that should not be retried when submitting a snapshot.
  *


### PR DESCRIPTION
Throwaway test targeting main directly to prove the check-dist required-status-check ruleset blocks merge when the release.yml workflow itself is touched + dist/ is left stale. Not for merging - will be closed after validation.