### PR TITLE
fix: fail the check-dist-build job too on a real dist/ mismatch

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -150,6 +150,7 @@ jobs:
       # (e.g. npm ci itself broke) - that's treated as "failure" below regardless of relevance,
       # since we can't vouch dist/ is fine if the rebuild couldn't even run.
       - name: Report check-dist status
+        id: report
         if: always()
         # Only tolerate a failure here for the one known cause: pull_request from a fork, where
         # GITHUB_TOKEN is forced read-only regardless of the permissions declared above (a hard
@@ -204,3 +205,18 @@ jobs:
             echo ""
             echo "$summary"
           } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "conclusion=$conclusion" >> "$GITHUB_OUTPUT"
+
+      # The custom "check-dist" Checks API entry above is detached from this job's own visible
+      # step list - GitHub's Actions UI only shows native jobs under a workflow run, never
+      # standalone Checks-API-created entries, so a genuine failure would otherwise show up as a
+      # fully green "check-dist-build" job here with no visible indication anything's wrong.
+      # Make the job fail too, but ONLY for the real, release-relevant failure case - never for
+      # "neutral" (which is legitimately non-blocking and shouldn't look alarming in the Actions
+      # tab), keeping the job's own status intuitively aligned with the public "check-dist" one.
+      - name: Fail the job on a release-relevant dist/ mismatch
+        if: ${{ steps.report.outputs.conclusion == 'failure' }}
+        run: |
+          echo "::error::check-dist reported 'failure' - see the 'Report check-dist status' step above for details."
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@
 # Delegates the tag/release mechanics to the shared reusable workflow in
 # advanced-security/reusable-workflows: https://github.com/advanced-security/reusable-workflows
 #
+# TEST: harmless comment to validate check-dist failure blocks merge under required ruleset when
+# this workflow file itself is touched. Will be reverted.
+#
 # Two ways to cut a release:
 #
 #   1. Normal flow - run this workflow (workflow_dispatch) with a "bump" type (patch/minor/major).

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,8 @@ import { retry } from '@octokit/plugin-retry';
 import { RequestError } from '@octokit/request-error';
 import * as toolkit from '@github/dependency-submission-toolkit';
 
+// TEST: validating check-dist failure blocks merge when release.yml workflow itself is touched. Will be reverted.
+
 /**
  * HTTP status codes that should not be retried when submitting a snapshot.
  *


### PR DESCRIPTION
## Problem

The custom `"check-dist"` Checks API entry (created via a raw API call in `check-dist-build`'s last step) is detached from that job's own visible step list - GitHub's Actions UI only shows native jobs under a workflow run, never standalone Checks-API-created entries. So a genuine release-relevant `dist/` mismatch previously showed as a **fully green** `check-dist-build` job/workflow run on the Actions tab, with the red "failure" verdict visible *only* on the separate PR-level `"check-dist"` check.

Confirmed live in #163/#164 (throwaway test PRs, since closed): `gh run list` showed the `Check dist/` workflow run itself as `conclusion: success`, even though the `check-dist` check-run correctly reported `failure` and blocked merge via the required ruleset. Someone glancing at the Actions tab (not the PR checks list) would see green and assume nothing's wrong.

## Fix

Add a final step that fails the job (`exit 1`) specifically when the "Report check-dist status" step determined `failure` - **not** for `neutral`, which is legitimately non-blocking and shouldn't look alarming in the Actions tab. This keeps the job's own status intuitively aligned with the public `"check-dist"` status for the one case that actually matters (a real, blocking problem), while leaving the neutral case exactly as before (job stays green, only the custom check shows the yellow nudge).

## Testing

Will re-validate live against a throwaway test PR (same pattern as #159's validation) to confirm the job now correctly shows red for the release-relevant failure case, while staying green for the neutral case.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
