### PR TITLE
fix: fail the check-dist-build job too on a real dist/ mismatch

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -150,6 +150,7 @@ jobs:
       # (e.g. npm ci itself broke) - that's treated as "failure" below regardless of relevance,
       # since we can't vouch dist/ is fine if the rebuild couldn't even run.
       - name: Report check-dist status
+        id: report
         if: always()
         # Only tolerate a failure here for the one known cause: pull_request from a fork, where
         # GITHUB_TOKEN is forced read-only regardless of the permissions declared above (a hard
@@ -204,3 +205,18 @@ jobs:
             echo ""
             echo "$summary"
           } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "conclusion=$conclusion" >> "$GITHUB_OUTPUT"
+
+      # The custom "check-dist" Checks API entry above is detached from this job's own visible
+      # step list - GitHub's Actions UI only shows native jobs under a workflow run, never
+      # standalone Checks-API-created entries, so a genuine failure would otherwise show up as a
+      # fully green "check-dist-build" job here with no visible indication anything's wrong.
+      # Make the job fail too, but ONLY for the real, release-relevant failure case - never for
+      # "neutral" (which is legitimately non-blocking and shouldn't look alarming in the Actions
+      # tab), keeping the job's own status intuitively aligned with the public "check-dist" one.
+      - name: Fail the job on a release-relevant dist/ mismatch
+        if: ${{ steps.report.outputs.conclusion == 'failure' }}
+        run: |
+          echo "::error::check-dist reported 'failure' - see the 'Report check-dist status' step above for details."
+          exit 1


### PR DESCRIPTION
## Problem

The custom `"check-dist"` Checks API entry (created via a raw API call in `check-dist-build`'s last step) is detached from that job's own visible step list - GitHub's Actions UI only shows native jobs under a workflow run, never standalone Checks-API-created entries. So a genuine release-relevant `dist/` mismatch previously showed as a **fully green** `check-dist-build` job/workflow run on the Actions tab, with the red "failure" verdict visible *only* on the separate PR-level `"check-dist"` check - confusing when glancing at the Actions tab instead of the PR checks list.

## Fix

Add a final step that fails the job (`exit 1`) specifically when the "Report check-dist status" step determined `failure` - **not** for `neutral`, which is legitimately non-blocking and shouldn't look alarming in the Actions tab. This keeps the job's own status intuitively aligned with the public `"check-dist"` status for the one case that actually matters (a real, blocking problem), while leaving the neutral case exactly as before (job stays green, only the custom check shows the yellow nudge).

(Supersedes #165, which was accidentally built on top of a leftover test-branch commit rather than a clean `main` - same fix, rebuilt cleanly here.)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
