### PR TITLE
TEST: verify check-dist-build job fails on real failure - will close

### DIFF
--- a/.release.yml
+++ b/.release.yml
@@ -1,6 +1,7 @@
 name: "spdx-dependency-submission-action"
 repository: "advanced-security/spdx-dependency-submission-action"
 version: "0.3.1"
+# TEST: verifying check-dist-build job itself now fails (red). Will be reverted.
 
 locations:
   - name: "Node Manifest"

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,8 @@ import { retry } from '@octokit/plugin-retry';
 import { RequestError } from '@octokit/request-error';
 import * as toolkit from '@github/dependency-submission-toolkit';
 
+// TEST: verifying check-dist-build job itself now fails (red) on a real release-relevant dist mismatch. Will be reverted.
+
 /**
  * HTTP status codes that should not be retried when submitting a snapshot.
  *


### PR DESCRIPTION
Throwaway test to verify the check-dist-build job itself now shows red (not just the detached check-dist entry) for a genuine release-relevant dist mismatch. Not for merging.