### PR TITLE
Add .npmrc with min-release-age=7 supply-chain safeguard

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# Supply-chain protection: refuse to install package versions published
+# within the last 7 days. Requires npm CLI 11.10.0+.
+min-release-age=7


### PR DESCRIPTION
## Summary
Adds a project-level `.npmrc` setting `min-release-age=7`, which tells npm to refuse installing any package version published within the last 7 days.

## Why
Recent supply-chain attacks (malicious versions published to popular packages) are typically caught and yanked within hours to a couple of days. A 7-day cooldown filters out most "smash-and-grab" incidents before they can land in installs.

## Compatibility
- Requires npm **>=11.10.0**.
- Verified locally: Node 26.7.0 bundles npm 12.0.2, which recognizes the setting (`npm config get min-release-age` → `7`).
- CI workflows (`test.yml`, `release.yml`, `check-dist.yml`) all use `actions/setup-node@v7.0.0` with `node-version: latest`, so they'll always resolve a current npm that supports this.

## Notes
- To bypass for an urgent hotfix install: `npm i --min-release-age 0 <package>@<version>`.