### PR TITLE
TEST: verify check-dist-build job stays green on neutral - will close

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,8 @@ import { retry } from '@octokit/plugin-retry';
 import { RequestError } from '@octokit/request-error';
 import * as toolkit from '@github/dependency-submission-toolkit';
 
+// TEST: verifying check-dist-build job stays green for a neutral (non-release-relevant) dist mismatch. Will be reverted.
+
 /**
  * HTTP status codes that should not be retried when submitting a snapshot.
  *


### PR DESCRIPTION
Throwaway test to verify the check-dist-build job still shows green for a non-release-relevant (neutral) dist mismatch, confirming the new fail-job step doesn't over-fire. Not for merging.