### PR TITLE
Address #168 review feedback: align Dependabot cooldown, document min-release-age bypass

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,9 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 3
+      # Aligned with .npmrc's min-release-age=7 so Dependabot doesn't propose
+      # versions that npm install/ci will then refuse until they're 7 days old.
+      default-days: 7
     reviewers:
       - "advanced-security/advanced-security-dependency-graph"
       - "advanced-security/oss-maintainers"

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 # Supply-chain protection: refuse to install package versions published
 # within the last 7 days. Requires npm CLI 11.10.0+.
+# For an urgent one-off install, bypass with: npm i --min-release-age 0 <package>@<version>
 min-release-age=7


### PR DESCRIPTION
## Summary
Follow-up to #168, addressing [review feedback](https://github.com/advanced-security/spdx-dependency-submission-action/pull/168#pullrequestreview-5001394090):

1. **Align Dependabot npm cooldown with `min-release-age`** — `.github/dependabot.yml`'s npm ecosystem had `cooldown.default-days: 3`, while `.npmrc` enforces `min-release-age=7`. This mismatch meant Dependabot could open PRs for versions that `npm ci`/`npm install` would then refuse until day 7. Raised `default-days` to `7` to match.
2. **Document the bypass** — Added a comment to `.npmrc` noting `npm i --min-release-age 0 <package>@<version>` for urgent one-off installs, so developers aren't confused by install failures caused by the policy.