### PR TITLE
TEST: verify simplified check-dist warning path - will close

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,8 @@ import { retry } from '@octokit/plugin-retry';
 import { RequestError } from '@octokit/request-error';
 import * as toolkit from '@github/dependency-submission-toolkit';
 
+// TEST: verifying the simplified check-dist warns (non-blocking) for a non-release-relevant stale dist. Will be reverted.
+
 /**
  * HTTP status codes that should not be retried when submitting a snapshot.
  *


### PR DESCRIPTION
Throwaway test to verify check-dist stays green with a warning annotation for a non-release-relevant stale-dist case. Not for merging.