### PR TITLE
TEST: verify simplified check-dist failure path - will close

### DIFF
--- a/.release.yml
+++ b/.release.yml
@@ -1,6 +1,7 @@
 name: "spdx-dependency-submission-action"
 repository: "advanced-security/spdx-dependency-submission-action"
 version: "0.3.1"
+# TEST: verifying the simplified check-dist fails (blocks) for a release-relevant stale dist. Will be reverted.
 
 locations:
   - name: "Node Manifest"

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,8 @@ import { retry } from '@octokit/plugin-retry';
 import { RequestError } from '@octokit/request-error';
 import * as toolkit from '@github/dependency-submission-toolkit';
 
+// TEST: verifying the simplified check-dist fails (blocks) for a release-relevant stale dist. Will be reverted.
+
 /**
  * HTTP status codes that should not be retried when submitting a snapshot.
  *


### PR DESCRIPTION
Throwaway test to verify check-dist correctly fails (blocks) for a release-relevant stale-dist case. Not for merging.