### PR TITLE
ci: simplify Patch Release Me 0.6.7 invocation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,28 +56,11 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Patch Release Me
-        # Invoke the pinned patch-release-me image directly via `docker run` instead of
-        # `uses: 42ByteLabs/patch-release-me@...`. That action's own action.yml builds its
-        # Docker CMD as a single YAML list item (`-m "${{ inputs.mode }}"`); Docker container
-        # actions don't go through a shell, so the literal quote characters end up baked into
-        # ONE argv token (`-m "minor"`). clap can't match that against "patch"/"minor"/"major"
-        # and silently falls back to its own default (Patch) - so `bump: minor`/`major` have
-        # always quietly produced a patch bump instead (see
-        # https://github.com/42ByteLabs/patch-release-me/issues/161, fixed upstream in
-        # https://github.com/42ByteLabs/patch-release-me/pull/162, not yet merged/released).
-        # Running the same pinned image ourselves via a normal shell `run:` step naturally
-        # splits `-m` and the mode value into separate argv entries, avoiding the bug entirely.
-        # Pinned by digest (not just tag) so the exact image content can't change out from
-        # under us - digest corresponds to the 0.6.5 tag, the last one with a published image
-        # (see https://github.com/42ByteLabs/patch-release-me/issues/159 for why 0.6.6 isn't used).
-        run: |
-          set -euo pipefail
-          docker run --rm \
-            --user "$(id -u):$(id -g)" \
-            -v "${{ github.workspace }}:/repo" \
-            -w /repo \
-            ghcr.io/42bytelabs/patch-release-me@sha256:d9d7abe7051855d0c395fec99d931acc002fb6b299ca16b8123e2c8ef0c7e750 \
-            --disable-banner bump -m ${{ inputs.bump }}
+        # TODO: Return to the upstream action after its runtime image is digest-pinned:
+        # https://github.com/42ByteLabs/patch-release-me/issues/169
+        uses: docker://ghcr.io/42bytelabs/patch-release-me:0.6.7@sha256:b9624359ce08707dfb4d22bcbf9d1a75f7f4718ccec610ddaa62280ffea98958
+        with:
+          args: --disable-banner bump -m ${{ inputs.bump }}
 
       - name: Setup Node
         uses: actions/setup-node@v7.0.0


### PR DESCRIPTION
## Summary

- Replace the manual Patch Release Me `docker run` workaround with GitHub's native Docker action syntax.
- Upgrade from the 0.6.5 image to 0.6.7 and pin the OCI image-index digest.
- Remove manual user, workspace mount, and working-directory plumbing.
- Document returning to the repository action after 42ByteLabs/patch-release-me#169 is resolved.

## Why

Patch Release Me 0.6.7 fixes the mode argument handling and has a published container image. Calling the image through `docker://...:0.6.7@sha256:...` preserves immutable execution while allowing GitHub Actions to manage the workspace and arguments.

The repository action is not used yet because its Dockerfile still references a mutable image tag.

## Validation

- Parsed the updated workflow as YAML.
- Ran `git diff --check`.
- Resolved the 0.6.7 OCI image-index digest with `docker buildx imagetools inspect`.
